### PR TITLE
feat!: support basic typedefs

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,7 +16,10 @@ use std::{
     process::ExitCode,
 };
 
-use c2e::{explainer::explain_declaration, parser::parser};
+use c2e::{
+    explainer::explain_declaration,
+    parser::{State, parser},
+};
 use chumsky::Parser;
 use fmt::{CliFormatter, ColorMap};
 use rustyline::{Config, DefaultEditor, error::ReadlineError};
@@ -75,6 +78,9 @@ fn main() -> ExitCode {
         termcolor::ColorChoice::Never
     });
 
+    // Persist state input lines
+    let mut parser_state = State::default();
+
     loop {
         match rl.readline("> ") {
             Ok(line) => {
@@ -105,7 +111,10 @@ fn main() -> ExitCode {
                     continue;
                 }
 
-                match parser().parse(&line).into_result() {
+                match parser()
+                    .parse_with_state(&line, &mut parser_state)
+                    .into_result()
+                {
                     Ok(decls) => match &decls[..] {
                         [decl] => {
                             let explanation = explain_declaration(decl);

--- a/lib/src/parser/error.rs
+++ b/lib/src/parser/error.rs
@@ -174,7 +174,7 @@ mod tests {
         let err = errs.first().unwrap();
         assert_eq!(
             err.to_string(),
-            "at 1..1: expected type qualifier or type, but found end of input"
+            "at 1..1: expected anything, type qualifier, or type, but found end of input"
         );
     }
 


### PR DESCRIPTION
Allows defining types using the `typedef` qualifier. Names of defined types are remembered and can be used as type names in later declarations, though the types they expand to are not yet remembered/expanded.